### PR TITLE
Added detection for non-resources xml file to prevent errors

### DIFF
--- a/src/org/roana0229/android_xml_sorter/XmlSorterAction.java
+++ b/src/org/roana0229/android_xml_sorter/XmlSorterAction.java
@@ -127,7 +127,7 @@ public class XmlSorterAction extends AnAction {
         if (file == null || !file.getName().endsWith(".xml")) return false;
         XMLStreamReader xml = null;
         try {
-            xml = XMLInputFactory.newFactory().createXMLStreamReader(file.getInputStream());
+            xml = XMLInputFactory.newInstance().createXMLStreamReader(file.getInputStream());
             while (xml.hasNext()) {
                 if (xml.next() == XMLStreamConstants.START_ELEMENT) {
                     return "resources".equals(xml.getLocalName());

--- a/src/org/roana0229/android_xml_sorter/XmlSorterAction.java
+++ b/src/org/roana0229/android_xml_sorter/XmlSorterAction.java
@@ -32,7 +32,7 @@ public class XmlSorterAction extends AnAction {
     public void update(AnActionEvent event) {
         super.update(event);
         final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(event.getDataContext());
-        event.getPresentation().setVisible(isResourceXmlFile(file));
+        event.getPresentation().setEnabledAndVisible(isResourceXmlFile(file));
     }
 
     @Override

--- a/src/org/roana0229/android_xml_sorter/XmlSorterUtil.java
+++ b/src/org/roana0229/android_xml_sorter/XmlSorterUtil.java
@@ -1,6 +1,5 @@
 package org.roana0229.android_xml_sorter;
 
-import org.apache.http.util.TextUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -85,8 +84,8 @@ public class XmlSorterUtil {
     }
 
     public static ArrayList<CommentedNode> insertDiffPrefixSpace(@NotNull Document document,
-                                                                 @NotNull ArrayList<CommentedNode> nodeList,
-                                                                 int prefixPosition, boolean isSnakeCase) {
+            @NotNull ArrayList<CommentedNode> nodeList,
+            int prefixPosition, boolean isSnakeCase) {
         ArrayList<CommentedNode> insertedList = new ArrayList<CommentedNode>();
         String beforePrefix = null;
 
@@ -107,7 +106,8 @@ public class XmlSorterUtil {
             }
 
             if (nodeList.indexOf(commentedNode) > 0) {
-                if (TextUtils.isEmpty(beforePrefix) || TextUtils.isEmpty(prefix) || !prefix.equals(beforePrefix)) {
+                if (beforePrefix == null || beforePrefix.isEmpty() || prefix == null || prefix.isEmpty()
+                        || !prefix.equals(beforePrefix)) {
                     Element element = document.createElement("space");
                     insertedList.add(new CommentedNode(element, null));
                 }


### PR DESCRIPTION
Hi, it's me again 😸 , thanks for this awesome plugin!

This PR adds detection for non-resources xml file, and hides menu entry for them.

For AndroidManifest.xml and so on:
![image](https://cloud.githubusercontent.com/assets/830358/23947471/df8103b8-09b9-11e7-81e0-bbc3ee14c767.png)

For strings.xml, arrays.xml and so on:
![image](https://cloud.githubusercontent.com/assets/830358/23947495/eeb37672-09b9-11e7-9922-8f23e41f021d.png)

