### PR TITLE
Add option to separate non-translatable strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Android Studio & IntelliJ Plugin for sort xml by name="xxx".
 * Insert version and encoding
 * Delete comment
 * Code indent number
+* Separate non-translatable strings
 
 # Installation
 

--- a/src/org/roana0229/android_xml_sorter/CommentedNode.java
+++ b/src/org/roana0229/android_xml_sorter/CommentedNode.java
@@ -1,6 +1,7 @@
 package org.roana0229.android_xml_sorter;
 
 import org.jetbrains.annotations.NotNull;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
 import java.util.ArrayList;
@@ -23,6 +24,12 @@ class CommentedNode {
     }
 
     static class Comparator implements java.util.Comparator<CommentedNode> {
+        private final boolean separateNonTranslatable;
+
+        public Comparator(boolean separateNonTranslatable) {
+            this.separateNonTranslatable = separateNonTranslatable;
+        }
+
         @Override
         public int compare(CommentedNode commentedNode1, CommentedNode commentedNode2) {
             Node node1 = commentedNode1.node, node2 = commentedNode2.node;
@@ -33,8 +40,21 @@ class CommentedNode {
             } else if (node1.getNodeType() != Node.COMMENT_NODE && node2.getNodeType() == Node.COMMENT_NODE) {
                 return 1;
             } else {
-                final String node1Name = node1.getAttributes().getNamedItem("name").getTextContent();
-                final String node2Name = node2.getAttributes().getNamedItem("name").getTextContent();
+                NamedNodeMap attributes1 = node1.getAttributes();
+                NamedNodeMap attributes2 = node2.getAttributes();
+                if (separateNonTranslatable) {
+                    Node translatable1 = attributes1.getNamedItem("translatable");
+                    Node translatable2 = attributes2.getNamedItem("translatable");
+                    final boolean isNotTranslatable1 = translatable1 != null && "false".equals(translatable1.getTextContent());
+                    final boolean isNotTranslatable2 = translatable2 != null && "false".equals(translatable2.getTextContent());
+                    if (isNotTranslatable1 && !isNotTranslatable2) {
+                        return 1;
+                    } else if (!isNotTranslatable1 && isNotTranslatable2) {
+                        return -1;
+                    }
+                }
+                final String node1Name = attributes1.getNamedItem("name").getTextContent();
+                final String node2Name = attributes2.getNamedItem("name").getTextContent();
                 return node1Name.compareTo(node2Name);
             }
         }

--- a/src/org/roana0229/android_xml_sorter/XmlInstantSorterAction.java
+++ b/src/org/roana0229/android_xml_sorter/XmlInstantSorterAction.java
@@ -25,7 +25,8 @@ public class XmlInstantSorterAction extends XmlSorterAction {
                 pc.getBoolean(PC_KEY_SPACE_BETWEEN_PREFIX, true),
                 pc.getBoolean(PC_KEY_INSERT_XML_INFO, true),
                 pc.getBoolean(PC_KEY_DELETE_COMMENT, false),
-                dialog.getCodeIndentValueAt(pc.getInt(PC_KEY_CODE_INDENT, 1)));
+                dialog.getCodeIndentValueAt(pc.getInt(PC_KEY_CODE_INDENT, 1)),
+                pc.getBoolean(PC_KEY_SEPARATE_NON_TRANSLATABLE, false));
     }
 
 }

--- a/src/org/roana0229/android_xml_sorter/XmlSorterAction.java
+++ b/src/org/roana0229/android_xml_sorter/XmlSorterAction.java
@@ -55,6 +55,7 @@ public class XmlSorterAction extends AnAction {
         boolean enableInsertXmlEncoding = dialog.enableInsertXmlInfo();
         boolean enableDeleteComment = dialog.enableDeleteComment();
         int codeIndent = dialog.getCodeIndent();
+        boolean separateNonTranslatable = dialog.separateNonTranslatableStrings();
         execute(project,
                 editor,
                 isSnakeCase,
@@ -62,7 +63,8 @@ public class XmlSorterAction extends AnAction {
                 enableInsertSpaceDiffPrefix,
                 enableInsertXmlEncoding,
                 enableDeleteComment,
-                codeIndent);
+                codeIndent,
+                separateNonTranslatable);
     }
 
     protected void execute(final Project project,
@@ -72,7 +74,8 @@ public class XmlSorterAction extends AnAction {
                            boolean enableInsertSpaceDiffPrefix,
                            boolean enableInsertXmlEncoding,
                            boolean enableDeleteComment,
-                           int codeIndent) {
+                           int codeIndent,
+                           boolean separateNonTranslatable) {
         // get content
         final String content = editor.getDocument().getText();
         final String simpleContent = XmlSorterUtil.replaceAllByRegex(content, ">\n*\\s+?<", "><");
@@ -88,7 +91,7 @@ public class XmlSorterAction extends AnAction {
 
         // sort
         ArrayList<CommentedNode> targetNodes = XmlSorterUtil.getNodesAsList(document);
-        Collections.sort(targetNodes, new CommentedNode.Comparator());
+        Collections.sort(targetNodes, new CommentedNode.Comparator(separateNonTranslatable));
         XmlSorterUtil.removeChildNodes(document);
 
         // insert space

--- a/src/org/roana0229/android_xml_sorter/XmlSorterDialog.form
+++ b/src/org/roana0229/android_xml_sorter/XmlSorterDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.roana0229.android_xml_sorter.XmlSorterDialog">
-  <grid id="27dc6" binding="mMainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mMainPanel" layout-manager="GridLayoutManager" row-count="7" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="578" height="400"/>
@@ -18,7 +18,7 @@
       </component>
       <component id="ce9ed" class="javax.swing.JCheckBox" binding="mInsertXmlInfoCheckBox">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Insert version and encoding"/>
@@ -26,7 +26,7 @@
       </component>
       <component id="96cd4" class="javax.swing.JLabel">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=" Code indent"/>
@@ -34,7 +34,7 @@
       </component>
       <component id="986c7" class="javax.swing.JComboBox" binding="mCodeIndentBox">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <model>
@@ -47,7 +47,7 @@
       </component>
       <component id="898cc" class="javax.swing.JCheckBox" binding="mDeleteCommentCheckBox">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Delete comment"/>
@@ -83,6 +83,14 @@
             <item value="Snake Case"/>
             <item value="Camel Case"/>
           </model>
+        </properties>
+      </component>
+      <component id="fb856" class="javax.swing.JCheckBox" binding="mSeparateNonTranslatableCheckBox">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Separate non-translatable strings"/>
         </properties>
       </component>
     </children>

--- a/src/org/roana0229/android_xml_sorter/XmlSorterDialog.java
+++ b/src/org/roana0229/android_xml_sorter/XmlSorterDialog.java
@@ -20,6 +20,7 @@ public class XmlSorterDialog extends DialogWrapper {
     static final String PC_KEY_DELETE_COMMENT = "PC_KEY_DELETE_COMMENT";
     static final String PC_KEY_INPUT_CASE = "PC_KEY_INPUT_CASE";
     static final String PC_KEY_CODE_INDENT = "PC_KEY_CODE_INDENT";
+    static final String PC_KEY_SEPARATE_NON_TRANSLATABLE = "PC_KEY_SEPARATE_NON_TRANSLATABLE";
 
     private JPanel mMainPanel;
     private JCheckBox mInsertSpaceCheckBox;
@@ -29,6 +30,7 @@ public class XmlSorterDialog extends DialogWrapper {
     private JCheckBox mDeleteCommentCheckBox;
     private JComboBox mCodeIndentBox;
     private JLabel mPrefixSpacePositionLabel;
+    private JCheckBox mSeparateNonTranslatableCheckBox;
 
     protected XmlSorterDialog(@Nullable Project project) {
         super(project, true);
@@ -41,13 +43,12 @@ public class XmlSorterDialog extends DialogWrapper {
     private void initComponent() {
         PropertiesComponent pc = PropertiesComponent.getInstance();
         mInsertSpaceCheckBox.setSelected(pc.getBoolean(PC_KEY_SPACE_BETWEEN_PREFIX, true));
-        // Snake Case
         mInputCaseBox.setSelectedIndex(pc.getInt(PC_KEY_INPUT_CASE, 0));
         mPrefixSpacePositionBox.setSelectedIndex(pc.getInt(PC_KEY_PREFIX_SPACE_POS, 0));
         mInsertXmlInfoCheckBox.setSelected(pc.getBoolean(PC_KEY_INSERT_XML_INFO, true));
         mDeleteCommentCheckBox.setSelected(pc.getBoolean(PC_KEY_DELETE_COMMENT, false));
-        // indent 4
         mCodeIndentBox.setSelectedIndex(pc.getInt(PC_KEY_CODE_INDENT, 1));
+        mSeparateNonTranslatableCheckBox.setSelected(pc.getBoolean(PC_KEY_SEPARATE_NON_TRANSLATABLE, false));
 
         ActionListener actionListener = new ActionListener() {
             @Override
@@ -100,6 +101,10 @@ public class XmlSorterDialog extends DialogWrapper {
         return Integer.parseInt(mCodeIndentBox.getItemAt(index).toString());
     }
 
+    public boolean separateNonTranslatableStrings() {
+        return mSeparateNonTranslatableCheckBox.isSelected();
+    }
+
     @Override
     protected void doOKAction() {
         save();
@@ -114,6 +119,7 @@ public class XmlSorterDialog extends DialogWrapper {
         pc.setValue(PC_KEY_INSERT_XML_INFO, mInsertXmlInfoCheckBox.isSelected(), true);
         pc.setValue(PC_KEY_DELETE_COMMENT, mDeleteCommentCheckBox.isSelected(), false);
         pc.setValue(PC_KEY_CODE_INDENT, mCodeIndentBox.getSelectedIndex(), 1);
+        pc.setValue(PC_KEY_SEPARATE_NON_TRANSLATABLE, mSeparateNonTranslatableCheckBox.isSelected(), false);
     }
 
 }


### PR DESCRIPTION
This pull request adds feature requested in #22 to group strings by "translatable" attribute.

![image](https://user-images.githubusercontent.com/5156340/42173845-a4728030-7e20-11e8-818d-fd4877f91402.png)

___

When selected all strings that have "translatable" attribute set to "false" will be placed after all of the other strings like here:

![image](https://user-images.githubusercontent.com/5156340/42173948-fa2d0932-7e20-11e8-949b-cdf91f72e71e.png)
